### PR TITLE
fix: Toggle buttons now work properly by using TabsContent components

### DIFF
--- a/src/app/main-content.tsx
+++ b/src/app/main-content.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -12,7 +11,7 @@ import { ChatInterface } from "@/components/chat/ChatInterface";
 import { FileTree } from "@/components/editor/FileTree";
 import { CodeEditor } from "@/components/editor/CodeEditor";
 import { PreviewFrame } from "@/components/preview/PreviewFrame";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { HeaderActions } from "@/components/HeaderActions";
 
 interface MainContentProps {
@@ -31,7 +30,6 @@ interface MainContentProps {
 }
 
 export function MainContent({ user, project }: MainContentProps) {
-  const [activeView, setActiveView] = useState<"preview" | "code">("preview");
 
   return (
     <FileSystemProvider initialData={project?.data}>
@@ -60,12 +58,7 @@ export function MainContent({ user, project }: MainContentProps) {
               <div className="h-full flex flex-col bg-white">
                 {/* Top Bar */}
                 <div className="h-14 border-b border-neutral-200/60 px-6 flex items-center justify-between bg-neutral-50/50">
-                  <Tabs
-                    value={activeView}
-                    onValueChange={(v) =>
-                      setActiveView(v as "preview" | "code")
-                    }
-                  >
+                  <Tabs defaultValue="preview">
                     <TabsList className="bg-white/60 border border-neutral-200/60 p-0.5 h-9 shadow-sm">
                       <TabsTrigger value="preview" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Preview</TabsTrigger>
                       <TabsTrigger value="code" className="data-[state=active]:bg-white data-[state=active]:text-neutral-900 data-[state=active]:shadow-sm text-neutral-600 px-4 py-1.5 text-sm font-medium transition-all">Code</TabsTrigger>
@@ -75,39 +68,39 @@ export function MainContent({ user, project }: MainContentProps) {
                 </div>
 
                 {/* Content Area */}
-                <div className="flex-1 overflow-hidden bg-neutral-50">
-                  {activeView === "preview" ? (
-                    <div className="h-full bg-white">
-                      <PreviewFrame />
-                    </div>
-                  ) : (
-                    <ResizablePanelGroup
-                      id="code-panel-group"
-                      direction="horizontal"
-                      className="h-full"
+                <TabsContent value="preview" className="flex-1 overflow-hidden bg-neutral-50 mt-0">
+                  <div className="h-full bg-white">
+                    <PreviewFrame />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="code" className="flex-1 overflow-hidden bg-neutral-50 mt-0">
+                  <ResizablePanelGroup
+                    id="code-panel-group"
+                    direction="horizontal"
+                    className="h-full"
+                  >
+                    {/* File Tree */}
+                    <ResizablePanel
+                      defaultSize={30}
+                      minSize={20}
+                      maxSize={50}
                     >
-                      {/* File Tree */}
-                      <ResizablePanel
-                        defaultSize={30}
-                        minSize={20}
-                        maxSize={50}
-                      >
-                        <div className="h-full bg-neutral-50 border-r border-neutral-200">
-                          <FileTree />
-                        </div>
-                      </ResizablePanel>
+                      <div className="h-full bg-neutral-50 border-r border-neutral-200">
+                        <FileTree />
+                      </div>
+                    </ResizablePanel>
 
-                      <ResizableHandle className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors" />
+                    <ResizableHandle className="w-[1px] bg-neutral-200 hover:bg-neutral-300 transition-colors" />
 
-                      {/* Code Editor */}
-                      <ResizablePanel defaultSize={70}>
-                        <div className="h-full bg-white">
-                          <CodeEditor />
-                        </div>
-                      </ResizablePanel>
-                    </ResizablePanelGroup>
-                  )}
-                </div>
+                    {/* Code Editor */}
+                    <ResizablePanel defaultSize={70}>
+                      <div className="h-full bg-white">
+                        <CodeEditor />
+                      </div>
+                    </ResizablePanel>
+                  </ResizablePanelGroup>
+                </TabsContent>
               </div>
             </ResizablePanel>
           </ResizablePanelGroup>


### PR DESCRIPTION
Fixes # 7

The Preview/Code toggle buttons were not working because the implementation was using manual conditional rendering instead of Radix UI's TabsContent components.

**Changes:**
- Added TabsContent import and components
- Replaced manual conditional rendering with proper TabsContent
- Removed unnecessary activeView state (Radix UI handles this internally)
- Set defaultValue='preview' for initial state

Generated with [Claude Code](https://claude.ai/code)